### PR TITLE
logging: Enable logging output to also go to console

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/resin-base:v4.3.0
+FROM resin/resin-base:v4.4.0
 
 RUN apt-get update && \
     apt-get install -yq --no-install-recommends \

--- a/config/services/balena-mdns-publisher.service
+++ b/config/services/balena-mdns-publisher.service
@@ -4,6 +4,8 @@ Requires=confd.service balena-root-ca.service
 After=confd.service balena-root-ca.service
 
 [Service]
+StandardOutput=journal+console
+StandardError=journal+console
 WorkingDirectory=/usr/src/app
 EnvironmentFile=/usr/src/app/config/env
 ExecStart=/usr/local/bin/npm start


### PR DESCRIPTION
This change allows output to be captured by the Supervisor
on resinOS devices when run as a service.

Connects-to: #3
Change-type: minor
Signed-off-by: Heds Simons <heds@resin.io>