### PR TITLE
Update apparmor security-opt example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Regardless of target, the service requires particular environment variables and 
             - SYS_RESOURCE
             - SYS_ADMIN
         security_opt:
-            - 'apparmor:unconfined'
+            - 'apparmor=unconfined'
         tmpfs:
             - /run
             - /sys/fs/cgroup
@@ -81,7 +81,7 @@ The following is an example of adding the balena mDNS publisher to a BoB instanc
             - SYS_RESOURCE
             - SYS_ADMIN
         security_opt:
-            - 'apparmor:unconfined'
+            - 'apparmor=unconfined'
         tmpfs:
             - /run
             - /sys/fs/cgroup


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Update `apparmor` security option example to use `=` instead of deprecated `:`.

```
time="2020-11-30T12:16:01.576318912+01:00" level=warning msg="Security options with `:` as a separator are deprecated and will be completely unsupported in 17.04, use `=` instead."
```